### PR TITLE
containers run as app user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
 FROM heroku/cedar:14
 
-ADD bin/build /usr/bin/build
-ADD bin/profile /usr/bin/profile
-ADD buildkit /buildkit
+COPY bin/build /usr/bin/build
+COPY bin/profile /usr/bin/profile
+COPY buildkit /buildkit
 
 ENV CURL_TIMEOUT 600
 ENV STACK cedar-14
 
-ONBUILD ENV PORT 3000
-ONBUILD EXPOSE 3000
-
-ONBUILD ENV HOME /app
-
-ONBUILD WORKDIR /build
-ONBUILD ADD . /build
+RUN apt-get -y update && apt-get install -y sudo && apt-get clean && \
+    adduser --disabled-password --gecos '' --ingroup sudo app && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ONBUILD ENTRYPOINT ["/usr/bin/profile"]
 
-ONBUILD RUN mkdir -p /cache
-ONBUILD RUN /usr/bin/build
+ONBUILD EXPOSE 3000
+ONBUILD ENV PORT 3000
+ONBUILD ENV HOME /app
+
+ONBUILD COPY . /build
+
+ONBUILD RUN mkdir -p /cache && \
+  /usr/bin/build /build /cache && \
+  rm -rf /app && \
+  mv /build /app
+
+ONBUILD USER app
+ONBUILD WORKDIR /app

--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,6 @@
 #!/bin/sh -e
+build_dir=$1
+cache_dir=$2
 
 buildpack="/buildkit"
 
@@ -7,8 +9,9 @@ if [ -f /build/.buildpacks ]; then
   buildpack="/tmp/multipack"
 fi
 
-$buildpack/bin/detect /build /cache
-$buildpack/bin/compile /build /cache
+mkdir -p $cache_dir
 
-rm -rf /app
-cp -r /build /app
+cd $build_dir
+
+$buildpack/bin/detect $build_dir $cache_dir
+$buildpack/bin/compile $build_dir $cache_dir


### PR DESCRIPTION
Docker's default is to run as root.  This causes problems with some Heroku-based apps that assume they are not-root, eg `npm run` will throw errors unless `--unsafe-perms` is provided.

To this end, change the user to `app`, change the working directory (the directory docker initially drops you in) to `/app`, and set `HOME=/app` in the environment.  Also install and grant password-less sudo rights to the `app` user.

/updates pivotal #106971496
/cc @anaulin 
