### PR TITLE
herokuish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM heroku/cedar:14
 
 COPY bin/build /usr/bin/build
 COPY bin/profile /usr/bin/profile
+COPY bin/start /usr/bin/start
 COPY buildkit /buildkit
 
 ENV CURL_TIMEOUT 600

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,29 @@
 FROM heroku/cedar:14
 
+RUN apt-get -y update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:vbernat/haproxy-1.6 && \
+    apt-get -y update && \
+    apt-get install -y haproxy sudo && \
+    apt-get clean && \
+    adduser --disabled-password --gecos '' --ingroup sudo app && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 COPY bin/build /usr/bin/build
 COPY bin/profile /usr/bin/profile
 COPY bin/start /usr/bin/start
+COPY bin/gen-cert /usr/bin/gen-cert
+COPY bin/web /usr/bin/web
 COPY buildkit /buildkit
+COPY conf/haproxy.cfg /etc/cedar/haproxy.cfg
 
 ENV CURL_TIMEOUT 600
 ENV STACK cedar-14
 
-RUN apt-get -y update && apt-get install -y sudo && apt-get clean && \
-    adduser --disabled-password --gecos '' --ingroup sudo app && \
-    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
 ONBUILD ENTRYPOINT ["/usr/bin/profile"]
 
-ONBUILD EXPOSE 3000
-ONBUILD ENV PORT 3000
+# for web processes
+ONBUILD EXPOSE 4443
 
 ONBUILD USER app
 ONBUILD ENV HOME /app

--- a/bin/gen-cert
+++ b/bin/gen-cert
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -ex
+
+# Script grifted from:
+# https://github.com/convox/rack/blob/master/api/bin/gen-cert
+
+mkdir -p /etc/cedar
+
+openssl genrsa -des3 -passout pass:x -out /etc/cedar/server.pass.key 2048
+openssl rsa -passin pass:x -in /etc/cedar/server.pass.key -out /etc/cedar/server.key
+
+rm /etc/cedar/server.pass.key
+
+openssl req -new -key /etc/cedar/server.key -out /etc/cedar/server.csr \
+  -subj "/C=US/ST=California/L=San Francisco/O=Good Eggs/OU=Kernel/CN=*.${AWS_REGION}.elb.amazonaws.com"
+openssl x509 -req -days 365 -in /etc/cedar/server.csr -signkey /etc/cedar/server.key -out /etc/cedar/server.crt
+
+cat /etc/cedar/server.crt /etc/cedar/server.key > /etc/cedar/server.pem

--- a/bin/profile
+++ b/bin/profile
@@ -4,4 +4,7 @@ for FILE in $(find /app/.profile.d/ -name '*.sh'); do
   source $FILE
 done
 
+# set a default DYNO
+export DYNO=run.`hostname`
+
 exec "$@"

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,25 @@
+#!/bin/bash
+APP_PATH=/app
+
+proc=$1
+
+if [ "$proc" == "" ]; then
+  echo "usage: start <process>"
+  exit 1
+fi
+
+procfile="$APP_PATH/Procfile"
+
+if [ ! -r $procfile ]; then
+  echo "cannot read $procfile"
+  exit 1
+fi
+
+cmd=`cat $APP_PATH/Procfile | grep "^[[:space:]]*$proc[[:space:]]*:" | sed "s/^[[:space:]]*$proc[[:space:]]*:[[:space:]]*//"`
+
+if [ "$cmd" == "" ]; then
+  echo "'$proc' process is not in your Procfile"
+  exit 1
+fi
+
+exec "$cmd"

--- a/bin/start
+++ b/bin/start
@@ -22,6 +22,8 @@ if [ "$cmd" == "" ]; then
   exit 1
 fi
 
+export DYNO=$proc.`hostname`
+
 if [ "$proc" == "web" ]; then
   exec web "$cmd"
 else

--- a/bin/start
+++ b/bin/start
@@ -22,4 +22,9 @@ if [ "$cmd" == "" ]; then
   exit 1
 fi
 
-exec "$cmd"
+if [ "$proc" == "web" ]; then
+  exec web "$cmd"
+else
+  exec "$cmd"
+fi
+

--- a/bin/web
+++ b/bin/web
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export AWS_REGION=`curl http://169.254.169.254/latest/dynamic/instance-identity/document|grep region|awk -F\" '{print $4}'`
+export PORT=3000
+
+gen-cert
+haproxy -f /etc/cedar/haproxy.cfg &
+
+exec "$@"

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -1,0 +1,76 @@
+# Grifted from:
+# https://github.com/convox/rack/blob/master/conf/haproxy.cfg
+
+#---------------------------------------------------------------------
+# Example configuration for a possible web application.  See the
+# full configuration options online.
+#
+#   http://haproxy.1wt.eu/download/1.4/doc/configuration.txt
+#
+#---------------------------------------------------------------------
+
+#---------------------------------------------------------------------
+# Global settings
+#---------------------------------------------------------------------
+global
+    # to have these messages end up in /var/log/haproxy.log you will
+    # need to:
+    #
+    # 1) configure syslog to accept network log events.  This is done
+    #    by adding the '-r' option to the SYSLOGD_OPTIONS in
+    #    /etc/sysconfig/syslog
+    #
+    # 2) configure local2 events to go to the /var/log/haproxy.log
+    #   file. A line like the following can be added to
+    #   /etc/sysconfig/syslog
+    #
+    #    local2.*                       /var/log/haproxy.log
+    #
+    log         127.0.0.1 local2
+
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # turn on stats unix socket
+    stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option http-server-close
+    option forwardfor       except 127.0.0.0/8
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          3600s
+    timeout server          3600s
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 3000
+
+#---------------------------------------------------------------------
+# main frontend which proxys to the backends
+#---------------------------------------------------------------------
+frontend main
+    bind *:4443 ssl crt /etc/cedar/server.pem
+    default_backend app
+
+#---------------------------------------------------------------------
+# round robin balancing between the various backends
+#---------------------------------------------------------------------
+backend app
+    server app1 0.0.0.0:3000
+    http-request set-header X-Forwarded-Port %[dst_port]
+    http-request add-header X-Forwarded-Proto https if { ssl_fc }


### PR DESCRIPTION
This PR modifies our base Heroku-like Docker image with a few features:
- adds `start` -- a command that inspects the Procfile as Heroku does. (eg your Docker command should be `start web` or `start worker`)
- sets DYNO environment variable as Heroku does.  custom commands get `run.<hostname>`, `start`ed processes get `<process>.<hostname>`
- for processes called `web`, we do extra stuff:
  - generate a self-signed wildcard cert for the ELB
  - start haproxy for SSL termination
  - set the PORT environment variable
